### PR TITLE
Fix problem with deleting all cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.3",
-  "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "compile": "tsc",
-    "copyTestAssets": "node ./scripts/prepareTest.js",
-    "buildTests": "npm run compile && npm run copyTestAssets",
-    "test": "npm run compile && npm run copyTestAssets && node ./out/test/runTest.js",
-    "download-api": "vscode-dts dev",
-    "postdownload-api": "vscode-dts main",
-    "webpack": "webpack --mode production && node ./scripts/optimizeTypings.js",
-    "webpack-link": "webpack --mode development && node ./scripts/optimizeTypings.js",
-    "webpack-dev": "webpack --mode development --watch"
-  },
-  "author": "Visual Studio Code Team",
-  "license": "MIT",
-  "dependencies": {
-    "uuid": "^3.3.2",
-    "vscode-languageclient": "7.0.0"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^5.0.1",
-    "@types/glob": "^7.1.1",
-    "@types/mocha": "^8.2.3",
-    "@types/node": "^12.19.12",
-    "@types/uuid": "^3.4.3",
-    "@types/vscode": "~1.53.0",
-    "glob": "^7.1.4",
-    "mocha": "^8.2.1",
-    "ts-loader": "^7.0.5",
-    "typescript": "^4.3.5",
-    "vscode-dts": "^0.3.1",
-    "vscode-test": "^1.3.0",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
-  }
+    "name": "@vscode/jupyter-lsp-middleware",
+    "version": "0.2.4",
+    "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "compile": "tsc",
+        "copyTestAssets": "node ./scripts/prepareTest.js",
+        "buildTests": "npm run compile && npm run copyTestAssets",
+        "test": "npm run compile && npm run copyTestAssets && node ./out/test/runTest.js",
+        "download-api": "vscode-dts dev",
+        "postdownload-api": "vscode-dts main",
+        "webpack": "webpack --mode production && node ./scripts/optimizeTypings.js",
+        "webpack-link": "webpack --mode development && node ./scripts/optimizeTypings.js",
+        "webpack-dev": "webpack --mode development --watch"
+    },
+    "author": "Visual Studio Code Team",
+    "license": "MIT",
+    "dependencies": {
+        "uuid": "^3.3.2",
+        "vscode-languageclient": "7.0.0"
+    },
+    "devDependencies": {
+        "@types/fs-extra": "^5.0.1",
+        "@types/glob": "^7.1.1",
+        "@types/mocha": "^8.2.3",
+        "@types/node": "^12.19.12",
+        "@types/uuid": "^3.4.3",
+        "@types/vscode": "~1.53.0",
+        "glob": "^7.1.4",
+        "mocha": "^8.2.1",
+        "ts-loader": "^7.0.5",
+        "typescript": "^4.3.5",
+        "vscode-dts": "^0.3.1",
+        "vscode-test": "^1.3.0",
+        "webpack": "^4.43.0",
+        "webpack-cli": "^3.3.11"
+    }
 }

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -128,6 +128,9 @@ export class NotebookConverter implements Disposable {
         // mark the cell is closed (which contains `document`)
         // when all cells are closed, we should return the concatDocument, so the language server will close it and clear diagnostics
         if (concatDocument && concatDocument.isComposeDocumentsAllClosed) {
+            // Regenerate the document on next event. Otherwise the concat document is invalid (it won't track cell additions)
+            this.activeDocuments.delete(key);
+
             return concatDocument;
         }
 

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -128,7 +128,10 @@ export class NotebookConverter implements Disposable {
         // mark the cell is closed (which contains `document`)
         // when all cells are closed, we should return the concatDocument, so the language server will close it and clear diagnostics
         if (concatDocument && concatDocument.isComposeDocumentsAllClosed) {
-            // Regenerate the document on next event. Otherwise the concat document is invalid (it won't track cell additions)
+            // Regenerate the document on next event. We could just mark 'firedOpen' as false,
+            // but the concat document has a bug where if all the cells are destroyed, the concat document
+            // stops tracking.
+            // So the alternative solution is to just regenerate on the next cell add.
             this.activeDocuments.delete(key);
 
             return concatDocument;


### PR DESCRIPTION
If you delete all cells in a notebook we tell the language server the concat document has closed.

However since 'firedOpen' is true on the concat document, the adding of a new cell doesn't cause a textDocument/open on the language server.

This change fixes that by forcing destruction of the concat document on deleting all cells.