### PR TITLE
Found some bugs with filtering based on URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { TextDocument, Uri } from 'vscode';
+
 export const NotebookCellScheme = 'vscode-notebook-cell';
 export const InteractiveInputScheme = 'vscode-interactive-input';
 export const InteractiveScheme = 'vscode-interactive';
@@ -22,6 +24,19 @@ export function isEqual(a: string[], b: string[]): boolean {
     }
 
     return true;
+}
+
+function isUri(resource?: Uri | any): resource is Uri {
+    if (!resource) {
+        return false;
+    }
+    const uri = resource as Uri;
+    return typeof uri.path === 'string' && typeof uri.scheme === 'string';
+}
+
+export function isNotebookCell(documentOrUri: TextDocument | Uri): boolean {
+    const uri = isUri(documentOrUri) ? documentOrUri : documentOrUri.uri;
+    return uri.scheme.includes(NotebookCellScheme) || uri.scheme.includes(InteractiveInputScheme);
 }
 
 export function splitLines(

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -123,7 +123,9 @@ export class NotebookConcatDocument implements TextDocument, IDisposable {
         this.updateCellTracking();
     }
 
-    notebook: NotebookDocument | undefined = undefined;
+    public get notebook(): NotebookDocument {
+        return this._notebook;
+    }
 
     public dispose(): void {
         this.onDidChangeSubscription.dispose();

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -448,6 +448,19 @@ export class NotebookConverter implements Disposable {
         return this.toIncomingLocationFromRange(cell, new Range(position, position)).range.start;
     }
 
+    public toIncomingUri(outgoingUri: Uri, range?: Range) {
+        const wrapper = this.getWrapperFromOutgoingUri(outgoingUri);
+        if (wrapper && wrapper.notebook) {
+            if (range) {
+                const location = wrapper.locationAt(range);
+                return location.uri;
+            } else {
+                return wrapper.notebook.uri;
+            }
+        }
+        return outgoingUri;
+    }
+
     private getTextDocumentAtLocation(location: Location): TextDocument | undefined {
         const key = NotebookConverter.getDocumentKey(location.uri);
         const wrapper = this.activeDocuments.get(key);
@@ -614,15 +627,6 @@ export class NotebookConverter implements Disposable {
     // Should be if it's in a notebook cell or if it's in a notebook concat document
     private locationNeedsConversion(locationUri: Uri): boolean {
         return locationUri.scheme === NotebookCellScheme || this.getWrapperFromOutgoingUri(locationUri) !== undefined;
-    }
-
-    private toIncomingUri(outgoingUri: Uri, range: Range) {
-        const wrapper = this.getWrapperFromOutgoingUri(outgoingUri);
-        if (wrapper) {
-            const location = wrapper.locationAt(range);
-            return location.uri;
-        }
-        return outgoingUri;
     }
 
     private toIncomingCompletion(cell: TextDocument, item: CompletionItem) {

--- a/src/test/suite/notebook.test.ts
+++ b/src/test/suite/notebook.test.ts
@@ -47,8 +47,12 @@ suite('Notebook tests', function () {
     const disposables: Disposable[] = [];
     let languageServer: LanguageServer | undefined = undefined;
     let allowIntellisense = true;
-    const shouldProvideIntellisense = (_uri: Uri) => {
-        return allowIntellisense;
+    let emptyNotebookUri: Uri | undefined;
+    const shouldProvideIntellisense = (uri: Uri) => {
+        if (emptyNotebookUri?.fsPath === uri.fsPath) {
+            return allowIntellisense;
+        }
+        return false;
     };
     this.timeout(120_000);
     suiteSetup(async function () {
@@ -66,7 +70,7 @@ suite('Notebook tests', function () {
     setup(async function () {
         traceInfo(`Start Test ${this.currentTest?.title}`);
         allowIntellisense = true;
-        await createEmptyPythonNotebook(disposables);
+        emptyNotebookUri = await createEmptyPythonNotebook(disposables);
         traceInfo(`Start Test (completed) ${this.currentTest?.title}`);
     });
     teardown(async function () {


### PR DESCRIPTION
shouldAllowIntellisense can change at run time. This means all language servers should at least know about the cells. We'll swallow events later on, but at least send open/change/close events to all language servers.

Additionally the URI passed into handleDiagnostics is an outgoing URI (meaning one that pylance understands). It has to be translated into an incoming URI (one that VS code understands) before being filtered.