### PR TITLE
Virtual concat document with extra lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,16 +1624,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "fast-myers-diff": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-myers-diff/-/fast-myers-diff-3.0.1.tgz",
+      "integrity": "sha512-e8p26utONwDXeSDkDqu4jaR3l3r6ZgQO2GWB178ePZxCfFoRPNTJVZylUEHHG6uZeRikL1zCc2sl4sIAs9c0UQ=="
     },
     "figgy-pudding": {
       "version": "3.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1624,6 +1624,11 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "author": "Visual Studio Code Team",
     "license": "MIT",
     "dependencies": {
+        "fast-diff": "^1.2.0",
         "sha.js": "^2.4.11",
         "vscode-languageclient": "7.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "author": "Visual Studio Code Team",
     "license": "MIT",
     "dependencies": {
-        "fast-diff": "^1.2.0",
+        "fast-myers-diff": "^3.0.1",
         "sha.js": "^2.4.11",
         "vscode-languageclient": "7.0.0"
     },

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -65,3 +65,12 @@ export function splitLines(
 export function score(document: TextDocument, selector: DocumentSelector): number {
     return languages.match(selector, document);
 }
+
+export function findLastIndex<T>(array: Array<T>, predicate: (e: T) => boolean) {
+    for (let i = array.length - 1; i >= 0; i--) {
+        if (predicate(array[i])) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -48,18 +48,9 @@ export function isInteractiveCell(cellUri: Uri): boolean {
     );
 }
 
-export function splitLines(
-    str: string,
-    splitOptions: { trim?: boolean; removeEmptyEntries?: boolean } = { removeEmptyEntries: true, trim: true }
-): string[] {
+export function splitLines(str: string): string[] {
     let lines = str.split(/\r?\n/g);
-    if (splitOptions && splitOptions.trim) {
-        lines = lines.map((line) => line.trim());
-    }
-    if (splitOptions && splitOptions.removeEmptyEntries) {
-        lines = lines.filter((line) => line.length > 0);
-    }
-    return lines;
+    return lines.slice(0, lines.length - 1); // Skip last empty item
 }
 
 export function score(document: TextDocument, selector: DocumentSelector): number {

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -377,7 +377,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
         }
     }
 
-    public outgoingPositionAt(location: vscode.Location): vscode.Position {
+    public concatPositionAt(location: vscode.Location): vscode.Position {
         // Range is range inside of a cell
         const span = this._spans.find((s) => s.uri.toString() === location.uri.toString());
 
@@ -410,7 +410,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
         return 0;
     }
 
-    public outgoingRangeOf(cellUri: vscode.Uri) {
+    public concatRangeOf(cellUri: vscode.Uri) {
         const index = this._spans.findIndex((c) => c.uri.toString() === cellUri.toString());
         const lastIndex = findLastIndex(this._spans, (c) => c.uri.toString() === cellUri.toString());
         const startOffset = index >= 0 ? this._spans[index].startOffset : 0;
@@ -425,7 +425,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
         return [...new Set(this._spans.map((c) => c.uri))];
     }
 
-    public incomingLocationAt(positionOrRange: vscode.Range | vscode.Position): vscode.Location {
+    public notebookLocationAt(positionOrRange: vscode.Range | vscode.Position): vscode.Location {
         // positionOrRange should be in concat ranges
         if (positionOrRange instanceof vscode.Position) {
             positionOrRange = new vscode.Range(positionOrRange, positionOrRange);
@@ -468,7 +468,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
         return new vscode.Position(startLine, startChar);
     }
 
-    public incomingOffsetAt(cellUri: vscode.Uri, concatOffset: number) {
+    public notebookOffsetAt(cellUri: vscode.Uri, concatOffset: number) {
         // Convert the offset to the real offset
         const realOffset = this.mapConcatToClosestRealOffset(concatOffset);
 

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -423,7 +423,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
     public realRangeOf(cellUri: vscode.Uri) {
         // Get all the real spans
         const realSpans = this._spans.filter((s) => s.uri.toString() == cellUri.toString() && s.inRealCell);
-        const startOffset = realSpans[0].startOffset | 0;
+        const startOffset = realSpans[0].startOffset || 0;
         const endOffset = realSpans.length > 0 ? realSpans[realSpans.length - 1].endOffset : startOffset;
 
         // Find the matching concat lines
@@ -440,18 +440,19 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
 
     public notebookLocationAt(positionOrRange: vscode.Range | vscode.Position): vscode.Location {
         // positionOrRange should be in concat ranges
-        if (positionOrRange instanceof vscode.Position) {
-            positionOrRange = new vscode.Range(positionOrRange, positionOrRange);
-        }
+        const range =
+            positionOrRange instanceof vscode.Position
+                ? new vscode.Range(positionOrRange, positionOrRange)
+                : positionOrRange;
 
         // Get the start and end line
-        let startLine: NotebookConcatLine | undefined = this._lines[positionOrRange.start.line];
-        let endLine = this._lines[positionOrRange.end.line];
+        let startLine: NotebookConcatLine | undefined = this._lines[range.start.line];
+        let endLine = this._lines[range.end.line];
 
         if (startLine && endLine) {
             // Compute offset range of lines
-            let startOffset = startLine.offset + positionOrRange.start.character;
-            let endOffset = endLine.offset + positionOrRange.end.character;
+            let startOffset = startLine.offset + range.start.character;
+            let endOffset = endLine.offset + range.end.character;
 
             // Find the spans that intersect this range that also have real code
             const spans = this._spans.filter(
@@ -473,7 +474,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
                         this.notebookPositionAt(
                             new vscode.Position(startLine.lineNumber, startOffset - startLine.offset)
                         ),
-                        this.notebookPositionAt(positionOrRange.end)
+                        this.notebookPositionAt(range.end)
                     )
                 };
             }
@@ -482,7 +483,7 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
         // Not in the real code, return an undefined URI
         return {
             uri: vscode.Uri.parse(''),
-            range: positionOrRange
+            range
         };
     }
 

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -125,6 +125,9 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
                     const newText = newSpans.map((s) => s.text).join('');
 
                     // Diff the two pieces of text
+                    // see docs here on what it returns: https://github.com/gliese1337/fast-myers-diff
+                    // Essentially it's an array of indices, one item in the array per change detected
+                    // indices are start/end offsets for each piece of text where the change occurred
                     const diff = [...fastMyersDiff.diff(oldText, newText)];
 
                     // Diff should have an array of numbers. These are

--- a/src/notebookConcatDocument.ts
+++ b/src/notebookConcatDocument.ts
@@ -439,12 +439,19 @@ export class NotebookConcatDocument implements vscode.TextDocument, vscode.Dispo
 
         // Concat range is easy, it's the actual line numbers.
         const startLine = this._lines[positionOrRange.start.line];
+        if (startLine) {
+            return {
+                uri: startLine.cellUri,
+                range: new vscode.Range(
+                    this.notebookPositionAt(positionOrRange.start),
+                    this.notebookPositionAt(positionOrRange.end)
+                )
+            };
+        }
+
         return {
-            uri: startLine.cellUri,
-            range: new vscode.Range(
-                this.notebookPositionAt(positionOrRange.start),
-                this.notebookPositionAt(positionOrRange.end)
-            )
+            uri: vscode.Uri.parse(''),
+            range: positionOrRange
         };
     }
 

--- a/src/notebookConcatLine.ts
+++ b/src/notebookConcatLine.ts
@@ -10,7 +10,13 @@ export class NotebookConcatLine implements vscode.TextLine {
     private _firstNonWhitespaceIndex: number | undefined;
     private _isEmpty: boolean | undefined;
 
-    constructor(private _contents: string, private _line: number, private _offset: number) {
+    constructor(
+        public cellUri: vscode.Uri,
+        private _contents: string,
+        private _line: number,
+        private _notebookLineNumber: number,
+        private _offset: number
+    ) {
         this._range = new vscode.Range(new vscode.Position(_line, 0), new vscode.Position(_line, _contents.length));
         this._rangeWithLineBreak = new vscode.Range(this.range.start, new vscode.Position(_line, _contents.length + 1));
     }
@@ -22,6 +28,9 @@ export class NotebookConcatLine implements vscode.TextLine {
     }
     public get lineNumber(): number {
         return this._line;
+    }
+    public get notebookLineNumber(): number {
+        return this._notebookLineNumber;
     }
     public get text(): string {
         return this._contents;

--- a/src/notebookConcatLine.ts
+++ b/src/notebookConcatLine.ts
@@ -10,13 +10,7 @@ export class NotebookConcatLine implements vscode.TextLine {
     private _firstNonWhitespaceIndex: number | undefined;
     private _isEmpty: boolean | undefined;
 
-    constructor(
-        public cellUri: vscode.Uri,
-        private _contents: string,
-        private _line: number,
-        private _notebookLineNumber: number,
-        private _offset: number
-    ) {
+    constructor(public cellUri: vscode.Uri, private _contents: string, private _line: number, private _offset: number) {
         this._range = new vscode.Range(new vscode.Position(_line, 0), new vscode.Position(_line, _contents.length));
         this._rangeWithLineBreak = new vscode.Range(this.range.start, new vscode.Position(_line, _contents.length + 1));
     }
@@ -28,9 +22,6 @@ export class NotebookConcatLine implements vscode.TextLine {
     }
     public get lineNumber(): number {
         return this._line;
-    }
-    public get notebookLineNumber(): number {
-        return this._notebookLineNumber;
     }
     public get text(): string {
         return this._contents;

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -234,6 +234,16 @@ export class NotebookConverter implements Disposable {
         return cellRange || new Range(new Position(0, 0), new Position(0, 0));
     }
 
+    public toRealRange(cell: TextDocument | Uri, cellRange: Range | undefined): Range {
+        const wrapper = this.getTextDocumentWrapper(cell);
+        if (wrapper) {
+            const uri = cell instanceof Uri ? <Uri>cell : cell.uri;
+            const range = wrapper.realRangeOf(uri);
+            return range || cellRange || new Range(new Position(0, 0), new Position(0, 0));
+        }
+        return cellRange || new Range(new Position(0, 0), new Position(0, 0));
+    }
+
     public toConcatContext(cell: TextDocument, context: CodeActionContext): CodeActionContext {
         return {
             ...context,

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -147,12 +147,16 @@ export class NotebookConverter implements Disposable {
             // Then for all the new ones, set their values.
             diagnostics.forEach((d) => {
                 const location = wrapper.notebookLocationAt(d.range);
-                let list = result.get(location.uri);
-                if (!list) {
-                    list = [];
-                    result.set(location.uri, list);
+
+                // Empty location means no fragment (no cell URI)
+                if (location.uri.fragment) {
+                    let list = result.get(location.uri);
+                    if (!list) {
+                        list = [];
+                        result.set(location.uri, list);
+                    }
+                    list.push(this.toNotebookDiagnostic(location.uri, d));
                 }
-                list.push(this.toNotebookDiagnostic(location.uri, d));
             });
         } else if (this.mapOfConcatDocumentsWithCellUris.has(uri.toString())) {
             (this.mapOfConcatDocumentsWithCellUris.get(uri.toString()) || [])

--- a/src/notebookConverter.ts
+++ b/src/notebookConverter.ts
@@ -124,7 +124,7 @@ export class NotebookConverter implements Disposable {
         return wrapper?.handleChange(event);
     }
 
-    public toIncomingDiagnosticsMap(uri: Uri, diagnostics: Diagnostic[]): Map<Uri, Diagnostic[]> {
+    public toNotebookDiagnosticsMap(uri: Uri, diagnostics: Diagnostic[]): Map<Uri, Diagnostic[]> {
         const wrapper = this.getWrapperFromOutgoingUri(uri);
         const result = new Map<Uri, Diagnostic[]>();
 
@@ -146,13 +146,13 @@ export class NotebookConverter implements Disposable {
 
             // Then for all the new ones, set their values.
             diagnostics.forEach((d) => {
-                const location = wrapper.incomingLocationAt(d.range);
+                const location = wrapper.notebookLocationAt(d.range);
                 let list = result.get(location.uri);
                 if (!list) {
                     list = [];
                     result.set(location.uri, list);
                 }
-                list.push(this.toIncomingDiagnostic(location.uri, d));
+                list.push(this.toNotebookDiagnostic(location.uri, d));
             });
         } else if (this.mapOfConcatDocumentsWithCellUris.has(uri.toString())) {
             (this.mapOfConcatDocumentsWithCellUris.get(uri.toString()) || [])
@@ -167,21 +167,21 @@ export class NotebookConverter implements Disposable {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    public toIncomingWorkspaceSymbols(symbols: SymbolInformation[] | null | undefined) {
+    public toNotebookWorkspaceSymbols(symbols: SymbolInformation[] | null | undefined) {
         if (Array.isArray(symbols)) {
-            return symbols.map(this.toIncomingWorkspaceSymbol.bind(this));
+            return symbols.map(this.toNotebookWorkspaceSymbol.bind(this));
         }
         return symbols ?? undefined;
     }
 
-    public toIncomingWorkspaceEdit(workspaceEdit: WorkspaceEdit | null | undefined): WorkspaceEdit | undefined {
+    public toNotebookWorkspaceEdit(workspaceEdit: WorkspaceEdit | null | undefined): WorkspaceEdit | undefined {
         if (workspaceEdit) {
             // Translate all of the text edits into a URI map
             const translated = new Map<Uri, TextEdit[]>();
             workspaceEdit.entries().forEach(([key, values]) => {
                 values.forEach((e) => {
                     // Location may move this edit to a different cell.
-                    const location = this.toIncomingLocationFromRange(key, e.range);
+                    const location = this.toNotebookLocationFromRange(key, e.range);
 
                     // Save this in the entry
                     let list = translated.get(location.uri);
@@ -204,83 +204,83 @@ export class NotebookConverter implements Disposable {
         return workspaceEdit ?? undefined;
     }
 
-    public toOutgoingDocument(cell: TextDocument): TextDocument {
+    public toConcatDocument(cell: TextDocument): TextDocument {
         const result = this.getTextDocumentWrapper(cell);
         return result?.getConcatDocument() || cell;
     }
 
-    public toOutgoingUri(cell: TextDocument | Uri): Uri {
+    public toConcatUri(cell: TextDocument | Uri): Uri {
         const uri = cell instanceof Uri ? <Uri>cell : cell.uri;
         const result = this.getTextDocumentWrapper(cell);
         return result ? result.concatUri : uri;
     }
 
-    public toOutgoingPosition(cell: TextDocument, position: Position): Position {
+    public toConcatPosition(cell: TextDocument, position: Position): Position {
         const wrapper = this.getTextDocumentWrapper(cell);
-        return wrapper ? wrapper.outgoingPositionAt(new Location(cell.uri, position)) : position;
+        return wrapper ? wrapper.concatPositionAt(new Location(cell.uri, position)) : position;
     }
 
-    public toOutgoingPositions(cell: TextDocument, positions: Position[]) {
-        return positions.map((p) => this.toOutgoingPosition(cell, p));
+    public toConcatPositions(cell: TextDocument, positions: Position[]) {
+        return positions.map((p) => this.toConcatPosition(cell, p));
     }
 
-    public toOutgoingRange(cell: TextDocument | Uri, cellRange: Range | undefined): Range {
+    public toConcatRange(cell: TextDocument | Uri, cellRange: Range | undefined): Range {
         const wrapper = this.getTextDocumentWrapper(cell);
         if (wrapper) {
             const uri = cell instanceof Uri ? <Uri>cell : cell.uri;
-            const range = wrapper.outgoingRangeOf(uri);
+            const range = wrapper.concatRangeOf(uri);
             return range || cellRange || new Range(new Position(0, 0), new Position(0, 0));
         }
         return cellRange || new Range(new Position(0, 0), new Position(0, 0));
     }
 
-    public toOutgoingContext(cell: TextDocument, context: CodeActionContext): CodeActionContext {
+    public toConcatContext(cell: TextDocument, context: CodeActionContext): CodeActionContext {
         return {
             ...context,
-            diagnostics: context.diagnostics.map(this.toOutgoingDiagnostic.bind(this, cell))
+            diagnostics: context.diagnostics.map(this.toConcatDiagnostic.bind(this, cell))
         };
     }
 
-    public toIncomingHover(cell: TextDocument, hover: Hover | null | undefined): Hover | undefined {
+    public toNotebookHover(cell: TextDocument, hover: Hover | null | undefined): Hover | undefined {
         if (hover && hover.range) {
             return {
                 ...hover,
-                range: this.toIncomingRange(cell, hover.range)
+                range: this.toNotebookRange(cell, hover.range)
             };
         }
         return hover ?? undefined;
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    public toIncomingCompletions(
+    public toNotebookCompletions(
         cell: TextDocument,
         completions: CompletionItem[] | CompletionList | null | undefined
     ) {
         if (completions) {
             if (Array.isArray(completions)) {
-                return completions.map(this.toIncomingCompletion.bind(this, cell));
+                return completions.map(this.toNotebookCompletion.bind(this, cell));
             }
             return {
                 ...completions,
-                items: completions.items.map(this.toIncomingCompletion.bind(this, cell))
+                items: completions.items.map(this.toNotebookCompletion.bind(this, cell))
             };
         }
         return completions;
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    public toIncomingLocations(location: Definition | Location | Location[] | LocationLink[] | null | undefined) {
+    public toNotebookLocations(location: Definition | Location | Location[] | LocationLink[] | null | undefined) {
         if (Array.isArray(location)) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return (<any>location).map(this.toIncomingLocationOrLink.bind(this));
+            return (<any>location).map(this.toNotebookLocationOrLink.bind(this));
         }
         if (location?.range) {
-            return this.toIncomingLocationFromRange(location.uri, location.range);
+            return this.toNotebookLocationFromRange(location.uri, location.range);
         }
         return location;
     }
 
-    public toIncomingHighlight(
+    public toNotebookHighlight(
         cell: TextDocument,
         highlight: DocumentHighlight[] | null | undefined
     ): DocumentHighlight[] | undefined {
@@ -293,7 +293,7 @@ export class NotebookConverter implements Disposable {
         }
         const result: DocumentHighlight[] = [];
         for (let h of highlight) {
-            const loc = wrapper.incomingLocationAt(h.range);
+            const loc = wrapper.notebookLocationAt(h.range);
             if (loc.uri.toString() === cell.uri.toString()) {
                 result.push({ ...h, range: loc.range });
             }
@@ -302,35 +302,35 @@ export class NotebookConverter implements Disposable {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    public toIncomingSymbols(cell: TextDocument, symbols: SymbolInformation[] | DocumentSymbol[] | null | undefined) {
+    public toNotebookSymbols(cell: TextDocument, symbols: SymbolInformation[] | DocumentSymbol[] | null | undefined) {
         if (symbols && Array.isArray(symbols) && symbols.length) {
             if (symbols[0] instanceof DocumentSymbol) {
-                return (<DocumentSymbol[]>symbols).map(this.toIncomingSymbolFromDocumentSymbol.bind(this, cell));
+                return (<DocumentSymbol[]>symbols).map(this.toNotebookSymbolFromDocumentSymbol.bind(this, cell));
             }
-            return (<SymbolInformation[]>symbols).map(this.toIncomingSymbolFromSymbolInformation.bind(this, cell.uri));
+            return (<SymbolInformation[]>symbols).map(this.toNotebookSymbolFromSymbolInformation.bind(this, cell.uri));
         }
         return symbols ?? undefined;
     }
 
-    public toIncomingSymbolFromSymbolInformation(cellUri: Uri, symbol: SymbolInformation): SymbolInformation {
+    public toNotebookSymbolFromSymbolInformation(cellUri: Uri, symbol: SymbolInformation): SymbolInformation {
         return {
             ...symbol,
-            location: this.toIncomingLocationFromRange(cellUri, symbol.location.range)
+            location: this.toNotebookLocationFromRange(cellUri, symbol.location.range)
         };
     }
 
-    public toIncomingDiagnostic(cell: TextDocument | Uri, diagnostic: Diagnostic): Diagnostic {
+    public toNotebookDiagnostic(cell: TextDocument | Uri, diagnostic: Diagnostic): Diagnostic {
         return {
             ...diagnostic,
-            range: this.toIncomingRange(cell, diagnostic.range),
+            range: this.toNotebookRange(cell, diagnostic.range),
             relatedInformation: diagnostic.relatedInformation
-                ? diagnostic.relatedInformation.map(this.toIncomingRelatedInformation.bind(this, cell))
+                ? diagnostic.relatedInformation.map(this.toNotebookRelatedInformation.bind(this, cell))
                 : undefined
         };
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public toIncomingActions(_cell: TextDocument, actions: (Command | CodeAction)[] | null | undefined): undefined {
+    public toNotebookActions(_cell: TextDocument, actions: (Command | CodeAction)[] | null | undefined): undefined {
         if (Array.isArray(actions)) {
             // Disable for now because actions are handled directly by the LS sometimes (at least in pylance)
             // If we translate or use them they will either
@@ -341,27 +341,27 @@ export class NotebookConverter implements Disposable {
         return actions ?? undefined;
     }
 
-    public toIncomingCodeLenses(cell: TextDocument, lenses: CodeLens[] | null | undefined): CodeLens[] | undefined {
+    public toNotebookCodeLenses(cell: TextDocument, lenses: CodeLens[] | null | undefined): CodeLens[] | undefined {
         if (Array.isArray(lenses)) {
             return lenses.map((c) => ({
                 ...c,
-                range: this.toIncomingRange(cell, c.range)
+                range: this.toNotebookRange(cell, c.range)
             }));
         }
         return lenses ?? undefined;
     }
 
-    public toIncomingEdits(cell: TextDocument, edits: TextEdit[] | null | undefined): TextEdit[] | undefined {
+    public toNotebookEdits(cell: TextDocument, edits: TextEdit[] | null | undefined): TextEdit[] | undefined {
         if (Array.isArray(edits)) {
             return edits.map((e) => ({
                 ...e,
-                range: this.toIncomingRange(cell, e.range)
+                range: this.toNotebookRange(cell, e.range)
             }));
         }
         return edits ?? undefined;
     }
 
-    public toIncomingRename(
+    public toNotebookRename(
         cell: TextDocument,
         rangeOrRename:
             | Range
@@ -380,24 +380,24 @@ export class NotebookConverter implements Disposable {
         | undefined {
         if (rangeOrRename) {
             if (rangeOrRename instanceof Range) {
-                return this.toIncomingLocationFromRange(cell, rangeOrRename).range;
+                return this.toNotebookLocationFromRange(cell, rangeOrRename).range;
             }
             return {
                 ...rangeOrRename,
-                range: this.toIncomingLocationFromRange(cell, rangeOrRename.range).range
+                range: this.toNotebookLocationFromRange(cell, rangeOrRename.range).range
             };
         }
         return rangeOrRename ?? undefined;
     }
 
-    public toIncomingDocumentLinks(
+    public toNotebookDocumentLinks(
         cell: TextDocument,
         links: DocumentLink[] | null | undefined
     ): DocumentLink[] | undefined {
         if (links && Array.isArray(links)) {
             return links.map((l) => {
                 const uri = l.target ? l.target : cell.uri;
-                const location = this.toIncomingLocationFromRange(uri, l.range);
+                const location = this.toNotebookLocationFromRange(uri, l.range);
                 return {
                     ...l,
                     range: location.range,
@@ -408,31 +408,31 @@ export class NotebookConverter implements Disposable {
         return links ?? undefined;
     }
 
-    public toIncomingRange(cell: TextDocument | Uri, range: Range): Range {
+    public toNotebookRange(cell: TextDocument | Uri, range: Range): Range {
         // This is dangerous as the URI is not remapped (location uri may be different)
-        return this.toIncomingLocationFromRange(cell, range).range;
+        return this.toNotebookLocationFromRange(cell, range).range;
     }
 
-    public toIncomingPosition(cell: TextDocument | Uri, position: Position): Position {
+    public toNotebookPosition(cell: TextDocument | Uri, position: Position): Position {
         // This is dangerous as the URI is not remapped (location uri may be different)
-        return this.toIncomingLocationFromRange(cell, new Range(position, position)).range.start;
+        return this.toNotebookLocationFromRange(cell, new Range(position, position)).range.start;
     }
 
-    public toIncomingOffset(cell: TextDocument | Uri, offset: number): number {
+    public toNotebookOffset(cell: TextDocument | Uri, offset: number): number {
         const uri = cell instanceof Uri ? <Uri>cell : cell.uri;
         const wrapper = this.getWrapperFromOutgoingUri(uri);
         if (wrapper) {
-            return wrapper.incomingOffsetAt(uri, offset);
+            return wrapper.notebookOffsetAt(uri, offset);
         }
         return offset;
     }
 
-    public toIncomingUri(outgoingUri: Uri, range?: Range) {
+    public toNotebookUri(outgoingUri: Uri, range?: Range) {
         const wrapper = this.getWrapperFromOutgoingUri(outgoingUri);
         let result: Uri | undefined;
         if (wrapper) {
             if (range) {
-                const location = wrapper.incomingLocationAt(range);
+                const location = wrapper.notebookLocationAt(range);
                 result = location.uri;
             } else {
                 result = wrapper.notebookUri;
@@ -449,7 +449,7 @@ export class NotebookConverter implements Disposable {
         return result || outgoingUri;
     }
 
-    public toIncomingColorInformations(cellUri: Uri, colorInformations: ColorInformation[] | null | undefined) {
+    public toNotebookColorInformations(cellUri: Uri, colorInformations: ColorInformation[] | null | undefined) {
         if (Array.isArray(colorInformations)) {
             // Need to filter out color information for other cells. Pylance
             // will return it for all.
@@ -457,7 +457,7 @@ export class NotebookConverter implements Disposable {
                 .map((c) => {
                     return {
                         color: c.color,
-                        location: this.toIncomingLocationFromRange(cellUri, c.range)
+                        location: this.toNotebookLocationFromRange(cellUri, c.range)
                     };
                 })
                 .filter((cl) => cl.location.uri.fragment == cellUri.fragment)
@@ -470,38 +470,38 @@ export class NotebookConverter implements Disposable {
         }
     }
 
-    public toIncomingColorPresentations(cellUri: Uri, colorPresentations: ColorPresentation[] | null | undefined) {
+    public toNotebookColorPresentations(cellUri: Uri, colorPresentations: ColorPresentation[] | null | undefined) {
         if (Array.isArray(colorPresentations)) {
             return colorPresentations.map((c) => {
                 return {
                     ...c,
                     additionalTextEdits: c.additionalTextEdits
-                        ? this.toIncomingTextEdits(cellUri, c.additionalTextEdits)
+                        ? this.toNotebookTextEdits(cellUri, c.additionalTextEdits)
                         : undefined,
-                    textEdit: c.textEdit ? this.toIncomingTextEdit(cellUri, c.textEdit) : undefined
+                    textEdit: c.textEdit ? this.toNotebookTextEdit(cellUri, c.textEdit) : undefined
                 };
             });
         }
     }
 
-    public toIncomingTextEdits(cellUri: Uri, textEdits: TextEdit[] | null | undefined) {
+    public toNotebookTextEdits(cellUri: Uri, textEdits: TextEdit[] | null | undefined) {
         if (Array.isArray(textEdits)) {
-            return textEdits.map((t) => this.toIncomingTextEdit(cellUri, t));
+            return textEdits.map((t) => this.toNotebookTextEdit(cellUri, t));
         }
     }
 
-    public toIncomingTextEdit(cellUri: Uri, textEdit: TextEdit) {
+    public toNotebookTextEdit(cellUri: Uri, textEdit: TextEdit) {
         return {
             ...textEdit,
-            range: this.toIncomingRange(cellUri, textEdit.range)
+            range: this.toNotebookRange(cellUri, textEdit.range)
         };
     }
 
-    public toIncomingFoldingRanges(cellUri: Uri, ranges: FoldingRange[] | null | undefined) {
+    public toNotebookFoldingRanges(cellUri: Uri, ranges: FoldingRange[] | null | undefined) {
         if (Array.isArray(ranges)) {
             return ranges
                 .map((r) =>
-                    this.toIncomingLocationFromRange(
+                    this.toNotebookLocationFromRange(
                         cellUri,
                         new Range(new Position(r.start, 0), new Position(r.end, 0))
                     )
@@ -516,85 +516,85 @@ export class NotebookConverter implements Disposable {
         }
     }
 
-    public toIncomingSelectionRanges(cellUri: Uri, ranges: SelectionRange[] | null | undefined) {
+    public toNotebookSelectionRanges(cellUri: Uri, ranges: SelectionRange[] | null | undefined) {
         if (Array.isArray(ranges)) {
-            return ranges.map((r) => this.toIncomingSelectionRange(cellUri, r));
+            return ranges.map((r) => this.toNotebookSelectionRange(cellUri, r));
         }
     }
 
-    public toIncomingSelectionRange(cellUri: Uri, range: SelectionRange): SelectionRange {
+    public toNotebookSelectionRange(cellUri: Uri, range: SelectionRange): SelectionRange {
         return {
-            parent: range.parent ? this.toIncomingSelectionRange(cellUri, range.parent) : undefined,
-            range: this.toIncomingRange(cellUri, range.range)
+            parent: range.parent ? this.toNotebookSelectionRange(cellUri, range.parent) : undefined,
+            range: this.toNotebookRange(cellUri, range.range)
         };
     }
 
-    public toIncomingCallHierarchyItems(
+    public toNotebookCallHierarchyItems(
         cellUri: Uri,
         items: CallHierarchyItem | CallHierarchyItem[] | null | undefined
     ) {
         if (Array.isArray(items)) {
-            return items.map((r) => this.toIncomingCallHierarchyItem(cellUri, r));
+            return items.map((r) => this.toNotebookCallHierarchyItem(cellUri, r));
         } else if (items) {
-            return this.toIncomingCallHierarchyItem(cellUri, items);
+            return this.toNotebookCallHierarchyItem(cellUri, items);
         }
         return undefined;
     }
 
-    public toIncomingCallHierarchyItem(cellUri: Uri, item: CallHierarchyItem) {
+    public toNotebookCallHierarchyItem(cellUri: Uri, item: CallHierarchyItem) {
         return {
             ...item,
             uri: cellUri,
-            range: this.toIncomingRange(cellUri, item.range),
-            selectionRange: this.toIncomingRange(cellUri, item.selectionRange)
+            range: this.toNotebookRange(cellUri, item.range),
+            selectionRange: this.toNotebookRange(cellUri, item.selectionRange)
         };
     }
 
-    public toIncomingCallHierarchyIncomingCallItems(
+    public toNotebookCallHierarchyIncomingCallItems(
         cellUri: Uri,
         items: CallHierarchyIncomingCall[] | null | undefined
     ) {
         if (Array.isArray(items)) {
-            return items.map((r) => this.toIncomingCallHierarchyIncomingCallItem(cellUri, r));
+            return items.map((r) => this.toNotebookCallHierarchyIncomingCallItem(cellUri, r));
         }
         return undefined;
     }
 
-    public toIncomingCallHierarchyIncomingCallItem(
+    public toNotebookCallHierarchyIncomingCallItem(
         cellUri: Uri,
         item: CallHierarchyIncomingCall
     ): CallHierarchyIncomingCall {
         return {
-            from: this.toIncomingCallHierarchyItem(cellUri, item.from),
-            fromRanges: item.fromRanges.map((r) => this.toIncomingRange(cellUri, r))
+            from: this.toNotebookCallHierarchyItem(cellUri, item.from),
+            fromRanges: item.fromRanges.map((r) => this.toNotebookRange(cellUri, r))
         };
     }
 
-    public toIncomingCallHierarchyOutgoingCallItems(
+    public toNotebookCallHierarchyOutgoingCallItems(
         cellUri: Uri,
         items: CallHierarchyOutgoingCall[] | null | undefined
     ) {
         if (Array.isArray(items)) {
-            return items.map((r) => this.toIncomingCallHierarchyOutgoingCallItem(cellUri, r));
+            return items.map((r) => this.toNotebookCallHierarchyOutgoingCallItem(cellUri, r));
         }
         return undefined;
     }
 
-    public toIncomingCallHierarchyOutgoingCallItem(
+    public toNotebookCallHierarchyOutgoingCallItem(
         cellUri: Uri,
         item: CallHierarchyOutgoingCall
     ): CallHierarchyOutgoingCall {
         return {
-            to: this.toIncomingCallHierarchyItem(cellUri, item.to),
-            fromRanges: item.fromRanges.map((r) => this.toIncomingRange(cellUri, r))
+            to: this.toNotebookCallHierarchyItem(cellUri, item.to),
+            fromRanges: item.fromRanges.map((r) => this.toNotebookRange(cellUri, r))
         };
     }
 
-    public toIncomingSemanticEdits(cellUri: Uri, items: SemanticTokensEdits | SemanticTokens | null | undefined) {
+    public toNotebookSemanticEdits(cellUri: Uri, items: SemanticTokensEdits | SemanticTokens | null | undefined) {
         if (items && 'edits' in items) {
             return {
                 ...items,
-                edits: items.edits.map((e) => this.toIncomingSemanticEdit(cellUri, e))
+                edits: items.edits.map((e) => this.toNotebookSemanticEdit(cellUri, e))
             };
         } else if (items) {
             return items;
@@ -602,20 +602,20 @@ export class NotebookConverter implements Disposable {
         return undefined;
     }
 
-    public toIncomingSemanticEdit(cellUri: Uri, edit: SemanticTokensEdit) {
+    public toNotebookSemanticEdit(cellUri: Uri, edit: SemanticTokensEdit) {
         return {
             ...edit,
-            start: this.toIncomingOffset(cellUri, edit.start)
+            start: this.toNotebookOffset(cellUri, edit.start)
         };
     }
 
-    public toIncomingSemanticTokens(cellUri: Uri, tokens: SemanticTokens | null | undefined) {
+    public toNotebookSemanticTokens(cellUri: Uri, tokens: SemanticTokens | null | undefined) {
         if (tokens) {
             const wrapper = this.getTextDocumentWrapper(cellUri);
             // First line offset is the wrong number. It is from the beginning of the concat doc and not the
             // cell.
             if (wrapper && tokens.data.length > 0) {
-                const startOfCell = wrapper.outgoingPositionAt(new Location(cellUri, new Position(0, 0)));
+                const startOfCell = wrapper.concatPositionAt(new Location(cellUri, new Position(0, 0)));
 
                 // Note to self: If tokenization stops working, might be pylance's fault. It does handle
                 // range requests but was returning stuff outside the range.
@@ -631,11 +631,11 @@ export class NotebookConverter implements Disposable {
         return undefined;
     }
 
-    public toIncomingLinkedEditingRanges(cellUri: Uri, items: LinkedEditingRanges | null | undefined) {
+    public toNotebookLinkedEditingRanges(cellUri: Uri, items: LinkedEditingRanges | null | undefined) {
         if (items) {
             return {
                 ...items,
-                ranges: items.ranges.map((e) => this.toIncomingRange(cellUri, e))
+                ranges: items.ranges.map((e) => this.toNotebookRange(cellUri, e))
             };
         }
     }
@@ -648,34 +648,34 @@ export class NotebookConverter implements Disposable {
         }
     }
 
-    private toIncomingWorkspaceSymbol(symbol: SymbolInformation): SymbolInformation {
+    private toNotebookWorkspaceSymbol(symbol: SymbolInformation): SymbolInformation {
         // Figure out what cell if any the symbol is for
-        return this.toIncomingSymbolFromSymbolInformation(symbol.location.uri, symbol);
+        return this.toNotebookSymbolFromSymbolInformation(symbol.location.uri, symbol);
     }
 
     /* Renable this if actions can be translated
-    private toIncomingAction(cell: TextDocument, action: Command | CodeAction): Command | CodeAction {
+    private toNotebookAction(cell: TextDocument, action: Command | CodeAction): Command | CodeAction {
         if (action instanceof CodeAction) {
             return {
                 ...action,
-                command: action.command ? this.toIncomingCommand(cell, action.command) : undefined,
+                command: action.command ? this.toNotebookCommand(cell, action.command) : undefined,
                 diagnostics: action.diagnostics
-                    ? action.diagnostics.map(this.toIncomingDiagnostic.bind(this, cell))
+                    ? action.diagnostics.map(this.toNotebookDiagnostic.bind(this, cell))
                     : undefined
             };
         }
-        return this.toIncomingCommand(cell, action);
+        return this.toNotebookCommand(cell, action);
     }
 
-    private toIncomingCommand(cell: TextDocument, command: Command): Command {
+    private toNotebookCommand(cell: TextDocument, command: Command): Command {
         return {
             ...command,
-            arguments: command.arguments ? command.arguments.map(this.toIncomingArgument.bind(this, cell)) : undefined
+            arguments: command.arguments ? command.arguments.map(this.toNotebookArgument.bind(this, cell)) : undefined
         };
     }
 
 
-    private toIncomingArgument(cell: TextDocument, argument: any): any {
+    private toNotebookArgument(cell: TextDocument, argument: any): any {
         // URIs in a command should be remapped to the cell document if part
         // of one of our open notebooks
         if (isUri(argument)) {
@@ -692,95 +692,95 @@ export class NotebookConverter implements Disposable {
         }
         if (typeof argument === 'object' && argument.hasOwnProperty('start') && argument.hasOwnProperty('end')) {
             // This is a range like object. Convert it too.
-            return this.toIncomingRange(cell, this.toRange(<Range>argument));
+            return this.toNotebookRange(cell, this.toRange(<Range>argument));
         }
         if (typeof argument === 'object' && argument.hasOwnProperty('line') && argument.hasOwnProperty('character')) {
             // This is a position like object. Convert it too.
-            return this.toIncomingPosition(cell, this.toPosition(<Position>argument));
+            return this.toNotebookPosition(cell, this.toPosition(<Position>argument));
         }
         return argument;
     }
     */
 
-    private toOutgoingDiagnostic(cell: TextDocument, diagnostic: Diagnostic): Diagnostic {
+    private toConcatDiagnostic(cell: TextDocument, diagnostic: Diagnostic): Diagnostic {
         return {
             ...diagnostic,
-            range: this.toOutgoingRange(cell, diagnostic.range),
+            range: this.toConcatRange(cell, diagnostic.range),
             relatedInformation: diagnostic.relatedInformation
-                ? diagnostic.relatedInformation.map(this.toOutgoingRelatedInformation.bind(this, cell))
+                ? diagnostic.relatedInformation.map(this.toConcatRelatedInformation.bind(this, cell))
                 : undefined
         };
     }
 
-    private toOutgoingRelatedInformation(
+    private toConcatRelatedInformation(
         cell: TextDocument,
         relatedInformation: DiagnosticRelatedInformation
     ): DiagnosticRelatedInformation {
-        const outgoingDoc = this.toOutgoingDocument(cell);
+        const outgoingDoc = this.toConcatDocument(cell);
         return {
             ...relatedInformation,
             location:
                 relatedInformation.location.uri === outgoingDoc.uri
-                    ? this.toOutgoingLocation(cell, relatedInformation.location)
+                    ? this.toConcatLocation(cell, relatedInformation.location)
                     : relatedInformation.location
         };
     }
 
-    private toOutgoingLocation(cell: TextDocument, location: Location): Location {
+    private toConcatLocation(cell: TextDocument, location: Location): Location {
         return {
-            uri: this.toOutgoingDocument(cell).uri,
-            range: this.toOutgoingRange(cell, location.range)
+            uri: this.toConcatDocument(cell).uri,
+            range: this.toConcatRange(cell, location.range)
         };
     }
 
-    private toIncomingRelatedInformation(
+    private toNotebookRelatedInformation(
         cell: TextDocument | Uri,
         relatedInformation: DiagnosticRelatedInformation
     ): DiagnosticRelatedInformation {
-        const outgoingUri = this.toOutgoingUri(cell);
+        const outgoingUri = this.toConcatUri(cell);
         return {
             ...relatedInformation,
             location:
                 relatedInformation.location.uri === outgoingUri
-                    ? this.toIncomingLocationFromLocation(relatedInformation.location)
+                    ? this.toNotebookLocationFromLocation(relatedInformation.location)
                     : relatedInformation.location
         };
     }
 
-    private toIncomingSymbolFromDocumentSymbol(cell: TextDocument, docSymbol: DocumentSymbol): DocumentSymbol {
+    private toNotebookSymbolFromDocumentSymbol(cell: TextDocument, docSymbol: DocumentSymbol): DocumentSymbol {
         return {
             ...docSymbol,
-            range: this.toIncomingRange(cell, docSymbol.range),
-            selectionRange: this.toIncomingRange(cell, docSymbol.selectionRange),
-            children: docSymbol.children.map(this.toIncomingSymbolFromDocumentSymbol.bind(this, cell))
+            range: this.toNotebookRange(cell, docSymbol.range),
+            selectionRange: this.toNotebookRange(cell, docSymbol.selectionRange),
+            children: docSymbol.children.map(this.toNotebookSymbolFromDocumentSymbol.bind(this, cell))
         };
     }
 
-    private toIncomingLocationFromLocation(location: Location): Location {
+    private toNotebookLocationFromLocation(location: Location): Location {
         if (this.locationNeedsConversion(location.uri)) {
-            const uri = this.toIncomingUri(location.uri, location.range);
+            const uri = this.toNotebookUri(location.uri, location.range);
 
             return {
                 uri,
-                range: this.toIncomingRange(uri, location.range)
+                range: this.toNotebookRange(uri, location.range)
             };
         }
 
         return location;
     }
 
-    private toIncomingLocationLinkFromLocationLink(locationLink: LocationLink): LocationLink {
+    private toNotebookLocationLinkFromLocationLink(locationLink: LocationLink): LocationLink {
         if (this.locationNeedsConversion(locationLink.targetUri)) {
-            const uri = this.toIncomingUri(locationLink.targetUri, locationLink.targetRange);
+            const uri = this.toNotebookUri(locationLink.targetUri, locationLink.targetRange);
 
             return {
                 originSelectionRange: locationLink.originSelectionRange
-                    ? this.toIncomingRange(uri, locationLink.originSelectionRange)
+                    ? this.toNotebookRange(uri, locationLink.originSelectionRange)
                     : undefined,
                 targetUri: uri,
-                targetRange: this.toIncomingRange(uri, locationLink.targetRange),
+                targetRange: this.toNotebookRange(uri, locationLink.targetRange),
                 targetSelectionRange: locationLink.targetSelectionRange
-                    ? this.toIncomingRange(uri, locationLink.targetSelectionRange)
+                    ? this.toNotebookRange(uri, locationLink.targetSelectionRange)
                     : undefined
             };
         }
@@ -788,13 +788,13 @@ export class NotebookConverter implements Disposable {
         return locationLink;
     }
 
-    private toIncomingLocationOrLink(location: Location | LocationLink) {
+    private toNotebookLocationOrLink(location: Location | LocationLink) {
         // Split on if we are dealing with a Location or a LocationLink
         if ('targetUri' in location) {
             // targetUri only for LocationLinks
-            return this.toIncomingLocationLinkFromLocationLink(location);
+            return this.toNotebookLocationLinkFromLocationLink(location);
         }
-        return this.toIncomingLocationFromLocation(location);
+        return this.toNotebookLocationFromLocation(location);
     }
 
     // Returns true if the given location needs conversion
@@ -803,31 +803,31 @@ export class NotebookConverter implements Disposable {
         return locationUri.scheme === NotebookCellScheme || this.getWrapperFromOutgoingUri(locationUri) !== undefined;
     }
 
-    private toIncomingCompletion(cell: TextDocument, item: CompletionItem) {
+    private toNotebookCompletion(cell: TextDocument, item: CompletionItem) {
         if (item.range) {
             if (item.range instanceof Range) {
                 return {
                     ...item,
-                    range: this.toIncomingRange(cell, item.range)
+                    range: this.toNotebookRange(cell, item.range)
                 };
             }
             return {
                 ...item,
                 range: {
-                    inserting: this.toIncomingRange(cell, item.range.inserting),
-                    replacing: this.toIncomingRange(cell, item.range.replacing)
+                    inserting: this.toNotebookRange(cell, item.range.inserting),
+                    replacing: this.toNotebookRange(cell, item.range.replacing)
                 }
             };
         }
         return item;
     }
 
-    private toIncomingLocationFromRange(cell: TextDocument | Uri, range: Range): Location {
+    private toNotebookLocationFromRange(cell: TextDocument | Uri, range: Range): Location {
         const uri = cell instanceof Uri ? <Uri>cell : cell.uri;
         const wrapper = this.getTextDocumentWrapper(cell);
         if (wrapper) {
-            const startLoc = wrapper.incomingLocationAt(range.start);
-            const endLoc = wrapper.incomingLocationAt(range.end);
+            const startLoc = wrapper.notebookLocationAt(range.start);
+            const endLoc = wrapper.notebookLocationAt(range.end);
             return {
                 uri: startLoc.uri,
                 range: new Range(startLoc.range.start, endLoc.range.end)

--- a/src/notebookMiddlewareAddon.ts
+++ b/src/notebookMiddlewareAddon.ts
@@ -784,7 +784,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
             const newDoc = this.converter.toConcatDocument(document);
 
             // Since tokens are for a cell, we need to change the request for a range and not the entire document.
-            const newRange = this.converter.toConcatRange(document.uri, undefined);
+            const newRange = this.converter.toRealRange(document.uri, undefined);
 
             const params: SemanticTokensRangeParams = {
                 textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(newDoc),

--- a/src/notebookWrapper.ts
+++ b/src/notebookWrapper.ts
@@ -100,6 +100,9 @@ export class NotebookWrapper implements vscode.Disposable {
     public concatRangeOf(cellUri: vscode.Uri) {
         return this.concatDocument.concatRangeOf(cellUri);
     }
+    public realRangeOf(cellUri: vscode.Uri) {
+        return this.concatDocument.realRangeOf(cellUri);
+    }
     public notebookOffsetAt(cellUri: vscode.Uri, offset: number) {
         return this.concatDocument.notebookOffsetAt(cellUri, offset);
     }

--- a/src/notebookWrapper.ts
+++ b/src/notebookWrapper.ts
@@ -85,11 +85,11 @@ export class NotebookWrapper implements vscode.Disposable {
     public getText(range?: vscode.Range) {
         return this.concatDocument.getText(range);
     }
-    public incomingLocationAt(positionOrRange: vscode.Range | vscode.Position) {
-        return this.concatDocument.incomingLocationAt(positionOrRange);
+    public notebookLocationAt(positionOrRange: vscode.Range | vscode.Position) {
+        return this.concatDocument.notebookLocationAt(positionOrRange);
     }
-    public outgoingPositionAt(location: vscode.Location) {
-        return this.concatDocument.outgoingPositionAt(location);
+    public concatPositionAt(location: vscode.Location) {
+        return this.concatDocument.concatPositionAt(location);
     }
     public getConcatDocument(): vscode.TextDocument {
         return this.concatDocument;
@@ -97,10 +97,10 @@ export class NotebookWrapper implements vscode.Disposable {
     public contains(cellUri: vscode.Uri) {
         return this.concatDocument.contains(cellUri);
     }
-    public outgoingRangeOf(cellUri: vscode.Uri) {
-        return this.concatDocument.outgoingRangeOf(cellUri);
+    public concatRangeOf(cellUri: vscode.Uri) {
+        return this.concatDocument.concatRangeOf(cellUri);
     }
-    public incomingOffsetAt(cellUri: vscode.Uri, offset: number) {
-        return this.concatDocument.incomingOffsetAt(cellUri, offset);
+    public notebookOffsetAt(cellUri: vscode.Uri, offset: number) {
+        return this.concatDocument.notebookOffsetAt(cellUri, offset);
     }
 }

--- a/src/notebookWrapper.ts
+++ b/src/notebookWrapper.ts
@@ -85,14 +85,11 @@ export class NotebookWrapper implements vscode.Disposable {
     public getText(range?: vscode.Range) {
         return this.concatDocument.getText(range);
     }
-    public locationAt(positionOrRange: vscode.Range | vscode.Position) {
-        return this.concatDocument.locationAt(positionOrRange);
+    public incomingLocationAt(positionOrRange: vscode.Range | vscode.Position) {
+        return this.concatDocument.incomingLocationAt(positionOrRange);
     }
-    public positionAt(offsetOrPosition: number | vscode.Position | vscode.Location) {
-        return this.concatDocument.positionAt(offsetOrPosition);
-    }
-    public offsetAt(position: vscode.Position | vscode.Location) {
-        return this.concatDocument.offsetAt(position);
+    public outgoingPositionAt(location: vscode.Location) {
+        return this.concatDocument.outgoingPositionAt(location);
     }
     public getConcatDocument(): vscode.TextDocument {
         return this.concatDocument;
@@ -100,10 +97,10 @@ export class NotebookWrapper implements vscode.Disposable {
     public contains(cellUri: vscode.Uri) {
         return this.concatDocument.contains(cellUri);
     }
-    public rangeOf(cellUri: vscode.Uri) {
-        return this.concatDocument.rangeOf(cellUri);
+    public outgoingRangeOf(cellUri: vscode.Uri) {
+        return this.concatDocument.outgoingRangeOf(cellUri);
     }
-    public cellOffsetAt(offset: number) {
-        return this.concatDocument.cellOffsetAt(offset);
+    public incomingOffsetAt(cellUri: vscode.Uri, offset: number) {
+        return this.concatDocument.incomingOffsetAt(cellUri, offset);
     }
 }

--- a/src/test/suite/concatTextDocument.test.ts
+++ b/src/test/suite/concatTextDocument.test.ts
@@ -151,64 +151,64 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
 
                 assert.strictEqual(
-                    concat.incomingLocationAt(new Position(0, 0)).uri.toString(),
+                    concat.notebookLocationAt(new Position(0, 0)).uri.toString(),
                     notebookDocument.getCells()[0].document.uri.toString()
                 );
                 assert.strictEqual(
-                    concat.incomingLocationAt(new Position(1, 0)).uri.toString(),
+                    concat.notebookLocationAt(new Position(1, 0)).uri.toString(),
                     notebookDocument.getCells()[2].document.uri.toString()
                 );
                 assert.strictEqual(
-                    concat.incomingLocationAt(new Position(2, 0)).uri.toString(),
+                    concat.notebookLocationAt(new Position(2, 0)).uri.toString(),
                     notebookDocument.getCells()[2].document.uri.toString()
                 );
                 assert.strictEqual(
-                    concat.incomingLocationAt(new Position(3, 0)).uri.toString(),
+                    concat.notebookLocationAt(new Position(3, 0)).uri.toString(),
                     inputDocument.uri.toString()
                 );
 
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 0))
                     ),
                     new Position(0, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 3))
                     ),
                     new Position(0, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 0))
                     ),
                     new Position(1, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 3))
                     ),
                     new Position(1, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 0))
                     ),
                     new Position(2, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(
+                    concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 3))
                     ),
                     new Position(2, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(new Location(inputDocument.uri, new Position(0, 0))),
+                    concat.concatPositionAt(new Location(inputDocument.uri, new Position(0, 0))),
                     new Position(3, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.outgoingPositionAt(new Location(inputDocument.uri, new Position(0, 3))),
+                    concat.concatPositionAt(new Location(inputDocument.uri, new Position(0, 3))),
                     new Position(3, 3)
                 );
             }
@@ -242,7 +242,7 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
                 assert.strictEqual(concat.getConcatDocument().lineAt(4).text, 'p.');
 
-                assert.deepStrictEqual(concat.incomingLocationAt(new Position(4, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.notebookLocationAt(new Position(4, 2)).range, new Range(1, 2, 1, 2));
             }
         );
     });
@@ -267,7 +267,7 @@ suite('concatTextDocument', () => {
                 // assert.strictEqual(concat.lineAt(3).text, 'print("bar")');
                 // assert.strictEqual(concat.lineAt(4).text, 'p.');
 
-                assert.deepStrictEqual(concat.incomingLocationAt(new Position(1, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.notebookLocationAt(new Position(1, 2)).range, new Range(1, 2, 1, 2));
             }
         );
     });

--- a/src/test/suite/concatTextDocument.test.ts
+++ b/src/test/suite/concatTextDocument.test.ts
@@ -50,7 +50,10 @@ suite('concatTextDocument', () => {
                     reason: undefined
                 });
 
-                assert.strictEqual(concat.getText(), ['print(1)', 'barfoo = 2', 'print(foo)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'barfoo = 2', 'print(foo)', ''].join('\n')
+                );
                 // Then deletion
                 concat.handleChange({
                     document: notebookDocument.cellAt(2).document,
@@ -65,7 +68,10 @@ suite('concatTextDocument', () => {
                     reason: undefined
                 });
 
-                assert.strictEqual(concat.getText(), ['print(1)', 'bar = 2', 'print(foo)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'bar = 2', 'print(foo)', ''].join('\n')
+                );
 
                 // Then replace
                 concat.handleChange({
@@ -81,7 +87,10 @@ suite('concatTextDocument', () => {
                     reason: undefined
                 });
 
-                assert.strictEqual(concat.getText(), ['print(1)', 'bar = 2', 'print(bar)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'bar = 2', 'print(bar)', ''].join('\n')
+                );
             }
         );
     });
@@ -98,7 +107,10 @@ suite('concatTextDocument', () => {
                 const concat = generateWrapper(notebookDocument);
                 assert.strictEqual(concat.getConcatDocument().lineCount, 4);
                 assert.strictEqual(concat.getConcatDocument().languageId, 'python');
-                assert.strictEqual(concat.getText(), ['print(1)', 'foo = 2', 'print(foo)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'foo = 2', 'print(foo)', ''].join('\n')
+                );
             }
         );
     });
@@ -113,13 +125,19 @@ suite('concatTextDocument', () => {
             ],
             (notebookDocument: NotebookDocument) => {
                 const concat = generateWrapper(notebookDocument);
-                assert.strictEqual(concat.getText(), ['print(1)', 'foo = 2', 'print(foo)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'foo = 2', 'print(foo)', ''].join('\n')
+                );
                 const firstCell = notebookDocument.getCells()[0];
                 const lastCell = notebookDocument.getCells()[2];
                 notebookDocument.getCells().splice(0, 1, lastCell);
                 notebookDocument.getCells().splice(2, 1, firstCell);
                 concat.handleRefresh(notebookDocument);
-                assert.strictEqual(concat.getText(), ['foo = 2', 'print(foo)', 'print(1)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'foo = 2', 'print(foo)', 'print(1)', ''].join('\n')
+                );
             }
         );
     });
@@ -143,20 +161,16 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().languageId, 'python');
                 assert.strictEqual(
                     concat.getText(),
-                    ['print(1)', 'foo = 2', 'print(foo)', 'print("bar")', ''].join('\n')
+                    ['import IPython', 'print(1)', 'foo = 2', 'print(foo)', 'print("bar")', ''].join('\n')
                 );
-                assert.strictEqual(concat.getConcatDocument().lineAt(0).text, 'print(1)');
-                assert.strictEqual(concat.getConcatDocument().lineAt(1).text, 'foo = 2');
-                assert.strictEqual(concat.getConcatDocument().lineAt(2).text, 'print(foo)');
-                assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
+                assert.strictEqual(concat.getConcatDocument().lineAt(1).text, 'print(1)');
+                assert.strictEqual(concat.getConcatDocument().lineAt(2).text, 'foo = 2');
+                assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print(foo)');
+                assert.strictEqual(concat.getConcatDocument().lineAt(4).text, 'print("bar")');
 
                 assert.strictEqual(
-                    concat.notebookLocationAt(new Position(0, 0)).uri.toString(),
-                    notebookDocument.getCells()[0].document.uri.toString()
-                );
-                assert.strictEqual(
                     concat.notebookLocationAt(new Position(1, 0)).uri.toString(),
-                    notebookDocument.getCells()[2].document.uri.toString()
+                    notebookDocument.getCells()[0].document.uri.toString()
                 );
                 assert.strictEqual(
                     concat.notebookLocationAt(new Position(2, 0)).uri.toString(),
@@ -164,6 +178,10 @@ suite('concatTextDocument', () => {
                 );
                 assert.strictEqual(
                     concat.notebookLocationAt(new Position(3, 0)).uri.toString(),
+                    notebookDocument.getCells()[2].document.uri.toString()
+                );
+                assert.strictEqual(
+                    concat.notebookLocationAt(new Position(4, 0)).uri.toString(),
                     inputDocument.uri.toString()
                 );
 
@@ -171,45 +189,45 @@ suite('concatTextDocument', () => {
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 0))
                     ),
-                    new Position(0, 0)
+                    new Position(1, 0)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 3))
                     ),
-                    new Position(0, 3)
+                    new Position(1, 3)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 0))
                     ),
-                    new Position(1, 0)
+                    new Position(2, 0)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 3))
                     ),
-                    new Position(1, 3)
+                    new Position(2, 3)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 0))
                     ),
-                    new Position(2, 0)
+                    new Position(3, 0)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(
                         new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 3))
                     ),
-                    new Position(2, 3)
+                    new Position(3, 3)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(new Location(inputDocument.uri, new Position(0, 0))),
-                    new Position(3, 0)
+                    new Position(4, 0)
                 );
                 assert.deepStrictEqual(
                     concat.concatPositionAt(new Location(inputDocument.uri, new Position(0, 3))),
-                    new Position(3, 3)
+                    new Position(4, 3)
                 );
             }
         );
@@ -234,15 +252,16 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().languageId, 'python');
                 assert.strictEqual(
                     concat.getText(),
-                    ['print(1)', 'foo = 2', 'print(foo)', 'print("bar")', 'p.', ''].join('\n')
+                    ['import IPython', 'print(1)', 'foo = 2', 'print(foo)', 'print("bar")', 'p.', ''].join('\n')
                 );
-                assert.strictEqual(concat.getConcatDocument().lineAt(0).text, 'print(1)');
-                assert.strictEqual(concat.getConcatDocument().lineAt(1).text, 'foo = 2');
-                assert.strictEqual(concat.getConcatDocument().lineAt(2).text, 'print(foo)');
-                assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
-                assert.strictEqual(concat.getConcatDocument().lineAt(4).text, 'p.');
+                assert.strictEqual(concat.getConcatDocument().lineAt(0).text, 'import IPython');
+                assert.strictEqual(concat.getConcatDocument().lineAt(1).text, 'print(1)');
+                assert.strictEqual(concat.getConcatDocument().lineAt(2).text, 'foo = 2');
+                assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print(foo)');
+                assert.strictEqual(concat.getConcatDocument().lineAt(4).text, 'print("bar")');
+                assert.strictEqual(concat.getConcatDocument().lineAt(5).text, 'p.');
 
-                assert.deepStrictEqual(concat.notebookLocationAt(new Position(4, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.notebookLocationAt(new Position(5, 2)).range, new Range(1, 2, 1, 2));
             }
         );
     });
@@ -267,7 +286,201 @@ suite('concatTextDocument', () => {
                 // assert.strictEqual(concat.lineAt(3).text, 'print("bar")');
                 // assert.strictEqual(concat.lineAt(4).text, 'p.');
 
-                assert.deepStrictEqual(concat.notebookLocationAt(new Position(1, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.notebookLocationAt(new Position(2, 2)).range, new Range(1, 2, 1, 2));
+            }
+        );
+    });
+
+    test('Cell with magics/shell escape/await', () => {
+        withTestNotebook(
+            Uri.from({ scheme: 'vscode-notebook', path: 'test.ipynb' }),
+            [
+                [['await print(1)'], 'python', NotebookCellKind.Code, [], {}],
+                [['test'], 'markdown', NotebookCellKind.Markup, [], {}],
+                [['%foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}],
+                [['%%foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}],
+                [['!foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}]
+            ],
+            (notebookDocument: NotebookDocument) => {
+                const concat = generateWrapper(notebookDocument);
+                assert.strictEqual(concat.getConcatDocument().lineCount, 8);
+                assert.strictEqual(concat.getConcatDocument().languageId, 'python');
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'await print(1) # type: ignore',
+                        '%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+            }
+        );
+    });
+
+    test('Edit a magic/shell/await', () => {
+        withTestNotebook(
+            Uri.from({ scheme: 'vscode-notebook', path: 'test.ipynb' }),
+            [
+                [['await print(1)'], 'python', NotebookCellKind.Code, [], {}],
+                [['test'], 'markdown', NotebookCellKind.Markup, [], {}],
+                [['%foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}],
+                [['%%foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}],
+                [['!foo = 2', 'print(foo)'], 'python', NotebookCellKind.Code, [], {}]
+            ],
+            (notebookDocument: NotebookDocument) => {
+                const concat = generateWrapper(notebookDocument);
+                assert.strictEqual(concat.getConcatDocument().lineCount, 8);
+                assert.strictEqual(concat.getConcatDocument().languageId, 'python');
+
+                // Try insertion
+                concat.handleChange({
+                    document: notebookDocument.cellAt(2).document,
+                    contentChanges: [
+                        {
+                            range: new Range(new Position(0, 0), new Position(0, 0)),
+                            rangeOffset: 0,
+                            rangeLength: 0,
+                            text: 'bar'
+                        }
+                    ],
+                    reason: undefined
+                });
+
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'await print(1) # type: ignore',
+                        'bar%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+
+                // Then deletion
+                concat.handleChange({
+                    document: notebookDocument.cellAt(0).document,
+                    contentChanges: [
+                        {
+                            range: new Range(new Position(0, 0), new Position(0, 1)),
+                            rangeOffset: 0,
+                            rangeLength: 0,
+                            text: ''
+                        }
+                    ],
+                    reason: undefined
+                });
+
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'wait print(1)',
+                        'bar%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+                // Undo deletion
+                concat.handleChange({
+                    document: notebookDocument.cellAt(0).document,
+                    contentChanges: [
+                        {
+                            range: new Range(new Position(0, 0), new Position(0, 0)),
+                            rangeOffset: 0,
+                            rangeLength: 0,
+                            text: 'a'
+                        }
+                    ],
+                    reason: undefined
+                });
+
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'await print(1) # type: ignore',
+                        'bar%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+                // Insertion after
+                concat.handleChange({
+                    document: notebookDocument.cellAt(0).document,
+                    contentChanges: [
+                        {
+                            range: new Range(new Position(0, 14), new Position(0, 14)),
+                            rangeOffset: 0,
+                            rangeLength: 0,
+                            text: '\n'
+                        }
+                    ],
+                    reason: undefined
+                });
+
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'await print(1) # type: ignore',
+                        '',
+                        'bar%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
+                // Replace whole line
+                concat.handleChange({
+                    document: notebookDocument.cellAt(0).document,
+                    contentChanges: [
+                        {
+                            range: new Range(new Position(0, 0), new Position(0, 14)),
+                            rangeOffset: 0,
+                            rangeLength: 0,
+                            text: 'dude'
+                        }
+                    ],
+                    reason: undefined
+                });
+
+                assert.strictEqual(
+                    concat.getText(),
+                    [
+                        'import IPython',
+                        'dude',
+                        '',
+                        'bar%foo = 2',
+                        'print(foo)',
+                        '%%foo = 2 # type: ignore',
+                        'print(foo)',
+                        '!foo = 2 # type: ignore',
+                        'print(foo)',
+                        ''
+                    ].join('\n')
+                );
             }
         );
     });

--- a/src/test/suite/concatTextDocument.test.ts
+++ b/src/test/suite/concatTextDocument.test.ts
@@ -151,49 +151,64 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
 
                 assert.strictEqual(
-                    concat.locationAt(new Position(0, 0)).uri.toString(),
+                    concat.incomingLocationAt(new Position(0, 0)).uri.toString(),
                     notebookDocument.getCells()[0].document.uri.toString()
                 );
                 assert.strictEqual(
-                    concat.locationAt(new Position(1, 0)).uri.toString(),
+                    concat.incomingLocationAt(new Position(1, 0)).uri.toString(),
                     notebookDocument.getCells()[2].document.uri.toString()
                 );
                 assert.strictEqual(
-                    concat.locationAt(new Position(2, 0)).uri.toString(),
+                    concat.incomingLocationAt(new Position(2, 0)).uri.toString(),
                     notebookDocument.getCells()[2].document.uri.toString()
                 );
-                assert.strictEqual(concat.locationAt(new Position(3, 0)).uri.toString(), inputDocument.uri.toString());
+                assert.strictEqual(
+                    concat.incomingLocationAt(new Position(3, 0)).uri.toString(),
+                    inputDocument.uri.toString()
+                );
 
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 0))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 0))
+                    ),
                     new Position(0, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 3))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[0].document.uri, new Position(0, 3))
+                    ),
                     new Position(0, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 0))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 0))
+                    ),
                     new Position(1, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 3))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[2].document.uri, new Position(0, 3))
+                    ),
                     new Position(1, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 0))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 0))
+                    ),
                     new Position(2, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 3))),
+                    concat.outgoingPositionAt(
+                        new Location(notebookDocument.getCells()[2].document.uri, new Position(1, 3))
+                    ),
                     new Position(2, 3)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(inputDocument.uri, new Position(0, 0))),
+                    concat.outgoingPositionAt(new Location(inputDocument.uri, new Position(0, 0))),
                     new Position(3, 0)
                 );
                 assert.deepStrictEqual(
-                    concat.positionAt(new Location(inputDocument.uri, new Position(0, 3))),
+                    concat.outgoingPositionAt(new Location(inputDocument.uri, new Position(0, 3))),
                     new Position(3, 3)
                 );
             }
@@ -227,7 +242,7 @@ suite('concatTextDocument', () => {
                 assert.strictEqual(concat.getConcatDocument().lineAt(3).text, 'print("bar")');
                 assert.strictEqual(concat.getConcatDocument().lineAt(4).text, 'p.');
 
-                assert.deepStrictEqual(concat.locationAt(new Position(4, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.incomingLocationAt(new Position(4, 2)).range, new Range(1, 2, 1, 2));
             }
         );
     });
@@ -252,7 +267,7 @@ suite('concatTextDocument', () => {
                 // assert.strictEqual(concat.lineAt(3).text, 'print("bar")');
                 // assert.strictEqual(concat.lineAt(4).text, 'p.');
 
-                assert.deepStrictEqual(concat.locationAt(new Position(1, 2)).range, new Range(1, 2, 1, 2));
+                assert.deepStrictEqual(concat.incomingLocationAt(new Position(1, 2)).range, new Range(1, 2, 1, 2));
             }
         );
     });

--- a/src/test/suite/editingTests.test.ts
+++ b/src/test/suite/editingTests.test.ts
@@ -19,24 +19,26 @@ suite('Editing Tests', () => {
             ],
             (notebookDocument: NotebookDocument) => {
                 const concat = generateWrapper(notebookDocument);
-                assert.strictEqual(concat.getConcatDocument().lineCount, 5);
+                assert.strictEqual(concat.getConcatDocument().lineCount, 6);
                 assert.strictEqual(concat.getConcatDocument().languageId, 'python');
                 assert.strictEqual(
                     concat.getText(),
-                    ['import IPython', 'print(1)', 'print(2)', 'foo = 2', 'print(foo)', ''].join('\n')
+                    ['import IPython\nIPython.get_ipython()', 'print(1)', 'print(2)', 'foo = 2', 'print(foo)', ''].join(
+                        '\n'
+                    )
                 );
 
                 // Verify if we delete markdown, we still have same count
                 const markdown = notebookDocument.getCells()[2];
                 notebookDocument.getCells().splice(2, 1);
                 concat.handleClose(markdown.document);
-                assert.strictEqual(concat.getConcatDocument().lineCount, 5);
+                assert.strictEqual(concat.getConcatDocument().lineCount, 6);
 
                 // Verify if we delete python, we still have new count
                 const python = notebookDocument.getCells()[1];
                 notebookDocument.getCells().splice(1, 1);
                 concat.handleClose(python.document);
-                assert.strictEqual(concat.getConcatDocument().lineCount, 4);
+                assert.strictEqual(concat.getConcatDocument().lineCount, 5);
             }
         );
     });

--- a/src/test/suite/editingTests.test.ts
+++ b/src/test/suite/editingTests.test.ts
@@ -21,7 +21,10 @@ suite('Editing Tests', () => {
                 const concat = generateWrapper(notebookDocument);
                 assert.strictEqual(concat.getConcatDocument().lineCount, 5);
                 assert.strictEqual(concat.getConcatDocument().languageId, 'python');
-                assert.strictEqual(concat.getText(), ['print(1)', 'print(2)', 'foo = 2', 'print(foo)', ''].join('\n'));
+                assert.strictEqual(
+                    concat.getText(),
+                    ['import IPython', 'print(1)', 'print(2)', 'foo = 2', 'print(foo)', ''].join('\n')
+                );
 
                 // Verify if we delete markdown, we still have same count
                 const markdown = notebookDocument.getCells()[2];

--- a/src/test/suite/notebook.test.ts
+++ b/src/test/suite/notebook.test.ts
@@ -194,12 +194,11 @@ suite('Notebook tests', function () {
             'System message not found'
         );
 
-        // Cell 2 should not
+        // Cell 2 should not have the 'system' problem
         cell2 = window.activeNotebookEditor?.document.cellAt(1)!;
         diagnostics = languages.getDiagnostics(cell2.document.uri);
-        assert.isEmpty(
-            diagnostics,
-            `No diagnostics should be found in the second cell: ${JSON.stringify(diagnostics)}`
+        assert.notOk(
+            diagnostics.find((item) => item.message.includes('system'), 'System diag should not be found after moving')
         );
 
         // Move cell back down, should have same results.

--- a/src/test/suite/notebook.test.ts
+++ b/src/test/suite/notebook.test.ts
@@ -197,7 +197,10 @@ suite('Notebook tests', function () {
         // Cell 2 should not
         cell2 = window.activeNotebookEditor?.document.cellAt(1)!;
         diagnostics = languages.getDiagnostics(cell2.document.uri);
-        assert.isEmpty(diagnostics, 'No diagnostics should be found in the second cell');
+        assert.isEmpty(
+            diagnostics,
+            `No diagnostics should be found in the second cell: ${JSON.stringify(diagnostics)}`
+        );
 
         // Move cell back down, should have same results.
         await focusCell(cell1);

--- a/src/test/suite/notebook.test.ts
+++ b/src/test/suite/notebook.test.ts
@@ -197,9 +197,7 @@ suite('Notebook tests', function () {
         // Cell 2 should not have the 'system' problem
         cell2 = window.activeNotebookEditor?.document.cellAt(1)!;
         diagnostics = languages.getDiagnostics(cell2.document.uri);
-        assert.notOk(
-            diagnostics.find((item) => item.message.includes('system'), 'System diag should not be found after moving')
-        );
+        assert.isEmpty(diagnostics, `Diagnostics should be empty after moving ${JSON.stringify(diagnostics)}`);
 
         // Move cell back down, should have same results.
         await focusCell(cell1);

--- a/test.js
+++ b/test.js
@@ -1,3 +1,0 @@
-const fd = require('fast-myers-diff')
-const d = [...fd.diff('await test() # type: ignore\nprint("foo")\n', '\nawait test() # type: ignore\nprint("foo")\n')]
-console.log(JSON.stringify(d))

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+const fd = require('fast-myers-diff')
+const d = [...fd.diff('await test() # type: ignore\nprint("foo")\n', '\nawait test() # type: ignore\nprint("foo")\n')]
+console.log(JSON.stringify(d))


### PR DESCRIPTION
This change is a new way to handle magics in the concat document. This is a prerequisite to solving bugs like:

https://github.com/microsoft/vscode-jupyter/issues/6987
https://github.com/microsoft/vscode-jupyter/issues/1510

Essentially there are two parallel documents - the real text entered by the user, and the text we send to pylance. 

These are tracked with a series of spans. Spans are in order from top of notebook to bottom with each span tracking:
- User entered (real) text
- Text for pylance (concat) text
- Offset in each set of text

These spans are then used to translate edits between the two different variations of the text. 

Edits were particularly difficult because they don't map to the edits in the original (real) text. I used something called [fast myers diff](https://www.npmjs.com/package/fast-myers-diff) to compute new offsets.