### PR TITLE
Fix token requests when doing edits to use 'real' range instead of concat range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.27",
+    "version": "0.2.28",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/notebookMiddlewareAddon.ts
+++ b/src/notebookMiddlewareAddon.ts
@@ -670,7 +670,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
     ): ProviderResult<ColorPresentation[]> {
         if (this.shouldProvideIntellisense(context.document.uri)) {
             const newDoc = this.converter.toConcatDocument(context.document);
-            const newRange = this.converter.toConcatRange(context.document, context.range);
+            const newRange = this.converter.toRealRange(context.document, context.range);
             const result = next(color, { document: newDoc, range: newRange }, token);
             if (isThenable(result)) {
                 return result.then(
@@ -754,7 +754,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
     ): ProviderResult<CallHierarchyIncomingCall[]> {
         if (this.shouldProvideIntellisense(item.uri)) {
             const newUri = this.converter.toConcatUri(item.uri);
-            const newRange = this.converter.toConcatRange(item.uri, item.range);
+            const newRange = this.converter.toRealRange(item.uri, item.range);
             const result = next({ ...item, uri: newUri, range: newRange }, token);
             if (isThenable(result)) {
                 return result.then(
@@ -771,7 +771,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
     ): ProviderResult<CallHierarchyOutgoingCall[]> {
         if (this.shouldProvideIntellisense(item.uri)) {
             const newUri = this.converter.toConcatUri(item.uri);
-            const newRange = this.converter.toConcatRange(item.uri, item.range);
+            const newRange = this.converter.toRealRange(item.uri, item.range);
             const result = next({ ...item, uri: newUri, range: newRange }, token);
             if (isThenable(result)) {
                 return result.then(
@@ -823,7 +823,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
             const newDoc = this.converter.toConcatDocument(document);
 
             // Since tokens are for a cell, we need to change the request for a range and not the entire document.
-            const newRange = this.converter.toConcatRange(document.uri, undefined);
+            const newRange = this.converter.toRealRange(document.uri, undefined);
 
             const params: SemanticTokensRangeParams = {
                 textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(newDoc),
@@ -848,7 +848,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
     ): ProviderResult<SemanticTokens> {
         if (this.shouldProvideIntellisense(document.uri)) {
             const newDoc = this.converter.toConcatDocument(document);
-            const newRange = this.converter.toConcatRange(document, range);
+            const newRange = this.converter.toRealRange(document, range);
             const result = next(newDoc, newRange, token);
             if (isThenable(result)) {
                 return result.then(this.converter.toNotebookSemanticTokens.bind(this.converter, document.uri));


### PR DESCRIPTION
Concat range includes 'hidden' lines. If we make a token request for those, we get back tokens for things that don't exist.

This was working for scrolling, but not during edits.