### PR TITLE
some refactoring on pylance middleware to share it with pylance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.30",
+    "version": "0.2.31",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { DocumentSelector, languages, TextDocument, Uri, NotebookDocument } from 'vscode';
-import { RefreshNotebookEvent } from './types';
+import { URI } from 'vscode-uri';
 
 export const NotebookScheme = 'vscode-notebook';
 export const NotebookCellScheme = 'vscode-notebook-cell';
@@ -28,20 +27,11 @@ export function isEqual(a: string[], b: string[]): boolean {
     return true;
 }
 
-function isUri(resource?: Uri | any): resource is Uri {
-    if (!resource) {
-        return false;
-    }
-    const uri = resource as Uri;
-    return typeof uri.path === 'string' && typeof uri.scheme === 'string';
-}
-
-export function isNotebookCell(documentOrUri: TextDocument | Uri): boolean {
-    const uri = isUri(documentOrUri) ? documentOrUri : documentOrUri.uri;
+export function isNotebookCell(uri: URI): boolean {
     return uri.scheme.includes(NotebookCellScheme) || uri.scheme.includes(InteractiveInputScheme);
 }
 
-export function isInteractiveCell(cellUri: Uri): boolean {
+export function isInteractiveCell(cellUri: URI): boolean {
     return (
         cellUri.fragment.includes(InteractiveScheme) ||
         cellUri.scheme.includes(InteractiveInputScheme) ||
@@ -54,10 +44,6 @@ export function splitLines(str: string): string[] {
     return lines.slice(0, lines.length - 1); // Skip last empty item
 }
 
-export function score(document: TextDocument, selector: DocumentSelector): number {
-    return languages.match(selector, document);
-}
-
 export function findLastIndex<T>(array: Array<T>, predicate: (e: T) => boolean) {
     for (let i = array.length - 1; i >= 0; i--) {
         if (predicate(array[i])) {
@@ -65,22 +51,4 @@ export function findLastIndex<T>(array: Array<T>, predicate: (e: T) => boolean) 
         }
     }
     return -1;
-}
-
-export function asRefreshEvent(notebook: NotebookDocument, selector: DocumentSelector): RefreshNotebookEvent {
-    return {
-        cells: notebook
-            .getCells()
-            .filter((c) => score(c.document, selector) > 0)
-            .map((c) => {
-                return {
-                    textDocument: {
-                        uri: c.document.uri.toString(),
-                        text: c.document.getText(),
-                        languageId: c.document.languageId,
-                        version: c.document.version
-                    }
-                };
-            })
-    };
 }

--- a/src/common/vscodeUtils.ts
+++ b/src/common/vscodeUtils.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { DocumentSelector, languages, TextDocument, NotebookDocument } from 'vscode';
+import { RefreshNotebookEvent } from './types';
+
+export function score(document: TextDocument, selector: DocumentSelector): number {
+    return languages.match(selector, document);
+}
+
+export function asRefreshEvent(notebook: NotebookDocument, selector: DocumentSelector): RefreshNotebookEvent {
+    return {
+        cells: notebook
+            .getCells()
+            .filter((c) => score(c.document, selector) > 0)
+            .map((c) => {
+                return {
+                    textDocument: {
+                        uri: c.document.uri.toString(),
+                        text: c.document.getText(),
+                        languageId: c.document.languageId,
+                        version: c.document.version
+                    }
+                };
+            })
+    };
+}

--- a/src/node/notebookMiddlewareAddon.ts
+++ b/src/node/notebookMiddlewareAddon.ts
@@ -5,7 +5,7 @@ import * as protocol from 'vscode-languageclient';
 import * as protocolNode from 'vscode-languageclient/node';
 
 import { ProvideDeclarationSignature } from 'vscode-languageclient/lib/common/declaration';
-import { asRefreshEvent, isInteractiveCell, isNotebookCell, isThenable } from '../common/utils';
+import { isInteractiveCell, isNotebookCell, isThenable } from '../common/utils';
 import { NotebookConverter } from '../protocol-only/notebookConverter';
 import { ProvideTypeDefinitionSignature } from 'vscode-languageclient/lib/common/typeDefinition';
 import { ProvideImplementationSignature } from 'vscode-languageclient/lib/common/implementation';
@@ -26,7 +26,7 @@ import {
     DocumentSemanticsTokensSignature
 } from 'vscode-languageclient/lib/common/semanticTokens';
 import { ProvideLinkedEditingRangeSignature } from 'vscode-languageclient/lib/common/linkedEditingRange';
-import { score } from '../common/utils';
+import { asRefreshEvent, score } from '../common/vscodeUtils';
 
 /**
  * This class is a temporary solution to handling intellisense and diagnostics in python based notebooks.

--- a/src/node/notebookMiddlewareAddon.ts
+++ b/src/node/notebookMiddlewareAddon.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import * as protocol from 'vscode-languageclient';
 import * as protocolNode from 'vscode-languageclient/node';
+import * as os from 'os';
 
 import { ProvideDeclarationSignature } from 'vscode-languageclient/lib/common/declaration';
 import { isInteractiveCell, isNotebookCell, isThenable } from '../common/utils';
@@ -46,7 +47,7 @@ export class NotebookMiddlewareAddon implements protocol.Middleware, vscode.Disp
         private readonly isDocumentAllowed: (uri: vscode.Uri) => boolean,
         getNotebookHeader: (uri: vscode.Uri) => string
     ) {
-        this.converter = new NotebookConverter(getNotebookHeader);
+        this.converter = new NotebookConverter(getNotebookHeader, () => os.platform());
 
         // Make sure a bunch of functions are bound to this. VS code can call them without a this context
         this.handleDiagnostics = this.handleDiagnostics.bind(this);

--- a/src/node/pylanceMiddlewareAddon.ts
+++ b/src/node/pylanceMiddlewareAddon.ts
@@ -76,7 +76,7 @@ import {
 } from 'vscode-languageclient/node';
 
 import { ProvideDeclarationSignature } from 'vscode-languageclient/lib/common/declaration';
-import { isThenable, score } from '../common/utils';
+import { isThenable } from '../common/utils';
 import { ProvideTypeDefinitionSignature } from 'vscode-languageclient/lib/common/typeDefinition';
 import { ProvideImplementationSignature } from 'vscode-languageclient/lib/common/implementation';
 import {
@@ -97,6 +97,7 @@ import {
 } from 'vscode-languageclient/lib/common/semanticTokens';
 import { ProvideLinkedEditingRangeSignature } from 'vscode-languageclient/lib/common/linkedEditingRange';
 import { RefreshNotebookEvent } from '../protocol-only/types';
+import { score } from '../common/vscodeUtils';
 
 /**
  * This class is a temporary solution to handling intellisense and diagnostics in python based notebooks.

--- a/src/test/suite/concatTextDocument.test.ts
+++ b/src/test/suite/concatTextDocument.test.ts
@@ -8,9 +8,10 @@ import * as path from 'path';
 import * as protocol from 'vscode-languageclient';
 import { generateConcat, InteractiveScheme, mockTextDocument, withTestNotebook } from './helper';
 import { TextDocument, NotebookCellKind, NotebookDocument, Uri, DocumentFilter, NotebookCell } from 'vscode';
-import { asRefreshEvent, InteractiveInputScheme, score } from '../../common/utils';
+import { InteractiveInputScheme } from '../../common/utils';
 import { NotebookConcatDocument } from '../../protocol-only/notebookConcatDocument';
 import { createLocation, createPosition, createRange } from '../../protocol-only/helper';
+import { asRefreshEvent, score } from '../../common/vscodeUtils';
 
 const HeaderText = 'import IPython\nIPython.get_ipython()';
 


### PR DESCRIPTION
- [x] remove vscode dependency from protocol-only
- [x] remove os dependency
- [x] custom lsp for notebook header - it looks like existing already handle this through options. (https://github.com/microsoft/vscode-jupyter-lsp-middleware/blob/main/src/node/pylanceMiddlewareAddon.ts#L137)

