### PR TITLE
more tweaks on shared code.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.31",
+    "version": "0.2.32",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",

--- a/src/protocol-only/notebookConcatDocument.ts
+++ b/src/protocol-only/notebookConcatDocument.ts
@@ -93,6 +93,10 @@ export class NotebookConcatDocument implements ITextDocument {
     private _lines: NotebookConcatLine[] = [];
     private _realLines: NotebookConcatLine[] = [];
 
+    public static getConcatDocRoot(cellUri: vscodeUri.URI) {
+        return path.dirname(cellUri.fsPath);
+    }
+
     constructor(public key: string, private readonly getNotebookHeader: (uri: vscodeUri.URI) => string) {}
 
     // Handles changes in the real cells and maps them to changes in the concat document.
@@ -879,7 +883,7 @@ export class NotebookConcatDocument implements ITextDocument {
     private initialize(cellUri: vscodeUri.URI) {
         if (!this._concatUri?.fsPath) {
             this._interactiveWindow = isInteractiveCell(cellUri);
-            const dir = path.dirname(cellUri.fsPath);
+            const dir = NotebookConcatDocument.getConcatDocRoot(cellUri);
 
             // Path has to match no matter how many times we open it.
             const concatFilePath = path.join(

--- a/src/protocol-only/notebookConverter.ts
+++ b/src/protocol-only/notebookConverter.ts
@@ -52,8 +52,14 @@ export class NotebookConverter implements IDisposable {
     }
 
     public isOpen(cell: protocol.TextDocumentIdentifier): boolean | undefined {
-        const concat = this.getConcatDocument(cell);
-        return concat.isOpen;
+        const uri = this.toURI(cell);
+        const key = this.getDocumentKey(uri);
+        const result = this.activeConcats.get(key);
+        if (!result) {
+            return false;
+        }
+
+        return result.isOpen;
     }
 
     public handleOpen(ev: protocol.DidOpenTextDocumentParams) {


### PR DESCRIPTION
1. Don't create a concat doc on isOpen call.
2. Provide a way to get concat doc root so that pylance can wait server for the doc to be initialized.