### PR TITLE
Disabled indexing on notebook pylance server.

### DIFF
--- a/src/node/notebookMiddlewareAddon.ts
+++ b/src/node/notebookMiddlewareAddon.ts
@@ -78,6 +78,10 @@ export class NotebookMiddlewareAddon implements protocol.Middleware, vscode.Disp
             for (const [i, item] of params.items.entries()) {
                 if (item.section === 'python') {
                     settings[i].pythonPath = this.pythonPath;
+
+                    // Always disable indexing on notebook. User can't use
+                    // auto import on notebook anyway.
+                    settings[i].analysis.indexing = false;
                 }
             }
 

--- a/src/node/pylanceMiddlewareAddon.ts
+++ b/src/node/pylanceMiddlewareAddon.ts
@@ -139,6 +139,10 @@ export class PylanceMiddlewareAddon implements Middleware, Disposable {
                     settings[i].notebookHeader = this.getNotebookHeader(
                         item.scopeUri ? Uri.parse(item.scopeUri) : Uri.parse('')
                     );
+
+                    // Always disable indexing on notebook. User can't use
+                    // auto import on notebook anyway.
+                    settings[i].analysis.indexing = false;
                 }
             }
 


### PR DESCRIPTION
auto import is disabled on notebook cells on concat doc. so creating indices is just waste work on notebook that use concat doc approach. This will tell notebook pylance server to disable indexing.