### PR TITLE
Change download-api to 'npx vscode-dts dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.39",
+    "version": "0.2.40",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",
@@ -10,7 +10,7 @@
         "compilewatch": "tsc -watch -p ./",
         "buildTests": "npm run download-api && npm run copyTestAssets && npm run compilewatch",
         "test": "npm run compile && npm run copyTestAssets && node ./out/test/runTest.js",
-        "download-api": "vscode-dts dev",
+        "download-api": "npx vscode-dts dev",
         "postdownload-api": "vscode-dts main",
         "webpack": "webpack --mode production && node ./scripts/optimizeTypings.js",
         "webpack-link": "webpack --mode development && node ./scripts/optimizeTypings.js",


### PR DESCRIPTION
@rchiodo suggested this as a fix for running vscode-dts post-install in vscode-python.  https://github.com/microsoft/vscode-python/pull/18742#discussion_r832513372