### PR TITLE
Replace postinstall step with prepare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/jupyter-lsp-middleware",
-  "version": "0.2.39",
+  "version": "0.2.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vscode/jupyter-lsp-middleware",
-    "version": "0.2.40",
+    "version": "0.2.41",
     "description": "VS Code Python Language Server Middleware for Jupyter Notebook",
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",
@@ -10,12 +10,12 @@
         "compilewatch": "tsc -watch -p ./",
         "buildTests": "npm run download-api && npm run copyTestAssets && npm run compilewatch",
         "test": "npm run compile && npm run copyTestAssets && node ./out/test/runTest.js",
-        "download-api": "npx vscode-dts dev",
+        "download-api": "vscode-dts dev",
         "postdownload-api": "vscode-dts main",
         "webpack": "webpack --mode production && node ./scripts/optimizeTypings.js",
         "webpack-link": "webpack --mode development && node ./scripts/optimizeTypings.js",
         "webpack-dev": "webpack --mode development --watch",
-        "postinstall": "npm run download-api"
+        "prepare": "npm run download-api"
     },
     "author": "Visual Studio Code Team",
     "license": "MIT",


### PR DESCRIPTION
Attempting to run vscode-dts when installing during vscode-python's builds is causing problems. Switching to npx (https://github.com/microsoft/vscode-jupyter-lsp-middleware/pull/44) did not fix the issue. So instead we're replacing the postinstall step with prepare which is only performed during install in development mode.

See https://docs.npmjs.com/cli/v6/using-npm/scripts#prepare-and-prepublish and https://stackoverflow.com/questions/23076968/npm-postinstall-only-on-development